### PR TITLE
Fixed a lint warning that was being shown in the cypress config file.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,6 +8,7 @@ module.exports = {
       jsx: true,
     },
   },
+  ignorePatterns: ['cypress.config.ts'],
   rules: {
     'react/react-in-jsx-scope': 0,
     'react/no-children-prop': 0,


### PR DESCRIPTION
Fixed a lint warning that was being shown in the cypress.config.js file. The file wasn't being ignored from the lint rules.